### PR TITLE
Rabbitmq server 15726

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,50 +44,50 @@ services:
       # HOST:CONTAINER
       - 8874:15672
       - 15694:15692
-  # perf-test-producer:
-  #   image: pivotalrabbitmq/perf-test:latest
-  #   networks:
-  #     - rabbitnet
-  #   command:
-  #     - --uri=amqp://haproxy
-  #     - --servers-startup-timeout=45
-  #     - --rate=10
-  #     - --producers=1
-  #     - --consumers=0
-  #     - --confirm=16
-  #     - --confirm-timeout=60
-  #     - --exclusive
-  #     - --type topic
-  #     - --exchange my.exchange
-  #     - --routing-key my.key
-  #     - --flag=mandatory
-  #     - --flag=persistent
-  #     - --size 64
-  #     - --queue-args=x-queue-type=classic
-  #   depends_on:
-  #     - rmq0
-  #     - rmq1
-  #     - rmq2
-  #     - haproxy
-  #   restart: on-failure
-  # perf-test-consumer:
-  #   image: pivotalrabbitmq/perf-test:latest
-  #   networks:
-  #     - rabbitnet
-  #   command:
-  #     - --uri=amqp://haproxy
-  #     - --servers-startup-timeout=45
-  #     - --producers=0
-  #     - --consumers=1
-  #     - --type topic
-  #     - --exchange my.exchange
-  #     - --routing-key my.key
-  #   depends_on:
-  #     - rmq0
-  #     - rmq1
-  #     - rmq2
-  #     - haproxy
-  #   restart: on-failure
+  perf-test-producer:
+    image: pivotalrabbitmq/perf-test:latest
+    networks:
+      - rabbitnet
+    command:
+      - --uri=amqp://haproxy
+      - --servers-startup-timeout=45
+      - --heartbeat=5
+      - --producers=1
+      - --consumers=0
+      - --exchange=update.exchange.number1
+      - --routing-key=key1
+      - --predeclared
+      - --rate=1
+      - --json-body
+      - --size=1000
+    depends_on:
+      - rmq0
+      - rmq1
+      - rmq2
+      - haproxy
+    restart: on-failure
+  perf-test-consumer:
+    image: pivotalrabbitmq/perf-test:latest
+    networks:
+      - rabbitnet
+    command:
+      - --uri=amqp://haproxy
+      - --servers-startup-timeout=45
+      - --heartbeat=5
+      - --producers=0
+      - --consumers=4
+      - --exchange=update.exchange.number1
+      - --type=topic
+      - --routing-key=key1
+      - --exclusive
+      - --auto-delete=true
+      - --qos=1
+    depends_on:
+      - rmq0
+      - rmq1
+      - rmq2
+      - haproxy
+    restart: on-failure
   haproxy:
     image: haproxy:latest
     networks:

--- a/rmq/advanced.config
+++ b/rmq/advanced.config
@@ -1,3 +1,3 @@
 [
-    {kernel, [{net_ticktime,  15}]}
+    {kernel, [{net_ticktime,  12}]}
 ].


### PR DESCRIPTION
- a single producer publishes 1 message per second (with a random JSON payload) to the existing topic-based exchange **update.exchange.number1** using routing key **key1**
- 4 consumers create auto-delete and exclusive classic queues to bind to this exchange & routing key
- heartbeat on both ends is set to 5s
- net_ticktime lowered from 15s to 12s